### PR TITLE
Fix CreateTests class name typo

### DIFF
--- a/HotelBediaX.Tests/UseCases/DestinationTest/CreateTests.cs
+++ b/HotelBediaX.Tests/UseCases/DestinationTest/CreateTests.cs
@@ -7,7 +7,7 @@ using Moq;
 
 namespace HotelBediaX.Tests.UseCases.DestinationTest
 {
-    public class CreateeTests
+    public class CreateTests
     {
         [Fact]
         public async Task Should_Call_Repository_And_Return_Id()


### PR DESCRIPTION
## Summary
- fix class name typo in destination creation tests

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bda29cecdc832fb3ee01c64f9a6919