### PR TITLE
Configure enum serialization in Web API

### DIFF
--- a/HotelBediaX.WebApi/Program.cs
+++ b/HotelBediaX.WebApi/Program.cs
@@ -1,8 +1,12 @@
 using HotelBediaX.WebApi.DI;
 
 var builder = WebApplication.CreateBuilder(args);
+builder.Services.AddControllers()
+    .AddJsonOptions(options =>
+    {
+        options.JsonSerializerOptions.Converters.Add(new System.Text.Json.Serialization.JsonStringEnumConverter());
+    });
 
-builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 builder.Services.AddProjectServices(builder.Configuration);
@@ -13,17 +17,11 @@ builder.Services.AddCors(options =>
     options.AddPolicy("AllowAngularClient",
         policy =>
         {
-            policy.WithOrigins("http://localhost:4200") 
+            policy.WithOrigins("http://localhost:4200")
                   .AllowAnyHeader()
                   .AllowAnyMethod();
         });
 });
-
-builder.Services.AddControllers()
-    .AddJsonOptions(options =>
-    {
-        options.JsonSerializerOptions.Converters.Add(new System.Text.Json.Serialization.JsonStringEnumConverter());
-    });
 
 
 var app = builder.Build();


### PR DESCRIPTION
## Summary
- ensure controllers serialize enums as strings via JsonStringEnumConverter
- remove duplicated AddControllers call in Program.cs

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68bda2a659cc832fa5c733ba5b2be5f1