### PR TITLE
Propagate cancellation tokens in destination operations

### DIFF
--- a/HotelBediaX.Application/Interfaces/IDestinationRepository.cs
+++ b/HotelBediaX.Application/Interfaces/IDestinationRepository.cs
@@ -1,14 +1,15 @@
-﻿using HotelBediaX.Application.UseCases.Common;
+using HotelBediaX.Application.UseCases.Common;
 using HotelBediaX.Domain.Entities;
+using System.Threading;
 
-namespace HotelBediaX.Application.Interfaces
+namespace HotelBediaX.Application.Interfaces;
+
+public interface IDestinationRepository
 {
-    public interface IDestinationRepository
-    {
-        Task<int> AddAsync(Destination destination);
-        Task<Destination?> GetByIdAsync(int id);
-        Task<Pagination<Destination>> GetAllAsync(int pageNumber, int pageSize, string? filter);
-        Task UpdateAsync(Destination destination);
-        Task DeleteAsync(int id);
-    }
+    Task<int> AddAsync(Destination destination, CancellationToken cancellationToken);
+    Task<Destination?> GetByIdAsync(int id, CancellationToken cancellationToken);
+    Task<Pagination<Destination>> GetAllAsync(int pageNumber, int pageSize, string? filter, CancellationToken cancellationToken);
+    Task UpdateAsync(Destination destination, CancellationToken cancellationToken);
+    Task DeleteAsync(int id, CancellationToken cancellationToken);
 }
+

--- a/HotelBediaX.Application/UseCases/DestinationUseCases/CreateUseCase.cs
+++ b/HotelBediaX.Application/UseCases/DestinationUseCases/CreateUseCase.cs
@@ -1,25 +1,26 @@
-﻿using HotelBediaX.Application.Interfaces;
+using HotelBediaX.Application.Interfaces;
 using HotelBediaX.Domain.Entities;
+using System.Threading;
 
-namespace HotelBediaX.Application.UseCases.DestinationUseCases
+namespace HotelBediaX.Application.UseCases.DestinationUseCases;
+
+public class CreateUseCase(IDestinationRepository repository)
 {
-    public class CreateUseCase(IDestinationRepository repository)
+    private readonly IDestinationRepository _repository = repository;
+
+    public async Task<int> ExecuteAsync(CreateDto dto, CancellationToken cancellationToken)
     {
-        private readonly IDestinationRepository _repository = repository;
-
-        public async Task<int> ExecuteAsync (CreateDto dto)
+        var destination = new Destination
         {
-            var destination = new Destination
-            {
-                Name = dto.Name,
-                CountryCode = dto.CountryCode,
-                Description = dto.Description,
-                Type = dto.Type,
-                CreatedDate = DateTime.UtcNow,
-                UpdatedDate = DateTime.UtcNow
-            };
+            Name = dto.Name,
+            CountryCode = dto.CountryCode,
+            Description = dto.Description,
+            Type = dto.Type,
+            CreatedDate = DateTime.UtcNow,
+            UpdatedDate = DateTime.UtcNow
+        };
 
-            return await _repository.AddAsync(destination);
-        }
+        return await _repository.AddAsync(destination, cancellationToken);
     }
 }
+

--- a/HotelBediaX.Application/UseCases/DestinationUseCases/DeleteUseCase.cs
+++ b/HotelBediaX.Application/UseCases/DestinationUseCases/DeleteUseCase.cs
@@ -1,14 +1,15 @@
-﻿using HotelBediaX.Application.Interfaces;
+using HotelBediaX.Application.Interfaces;
+using System.Threading;
 
-namespace HotelBediaX.Application.UseCases.DestinationUseCases
+namespace HotelBediaX.Application.UseCases.DestinationUseCases;
+
+public class DeleteUseCase(IDestinationRepository repository)
 {
-    public class DeleteUseCase(IDestinationRepository repository)
-    {
-        private readonly IDestinationRepository _repository = repository;
+    private readonly IDestinationRepository _repository = repository;
 
-        public async Task ExecuteAsync(int id)
-        {
-            await _repository.DeleteAsync(id);
-        }
+    public async Task ExecuteAsync(int id, CancellationToken cancellationToken)
+    {
+        await _repository.DeleteAsync(id, cancellationToken);
     }
 }
+

--- a/HotelBediaX.Application/UseCases/DestinationUseCases/GetAllUseCase.cs
+++ b/HotelBediaX.Application/UseCases/DestinationUseCases/GetAllUseCase.cs
@@ -1,6 +1,7 @@
-﻿using HotelBediaX.Application.Interfaces;
+using HotelBediaX.Application.Interfaces;
 using HotelBediaX.Application.UseCases.Common;
 using HotelBediaX.Domain.Entities;
+using System.Threading;
 
 namespace HotelBediaX.Application.UseCases.DestinationUseCases;
 
@@ -11,8 +12,10 @@ public class GetAllUseCase(IDestinationRepository repository)
     public async Task<Pagination<Destination>> ExecuteAsync(
         int pageNumber = 1,
         int pageSize = 10,
-        string? filter = null)
+        string? filter = null,
+        CancellationToken cancellationToken = default)
     {
-        return await _repository.GetAllAsync(pageNumber, pageSize, filter);
+        return await _repository.GetAllAsync(pageNumber, pageSize, filter, cancellationToken);
     }
 }
+

--- a/HotelBediaX.Application/UseCases/DestinationUseCases/GetByIdUseCase.cs
+++ b/HotelBediaX.Application/UseCases/DestinationUseCases/GetByIdUseCase.cs
@@ -1,5 +1,6 @@
-﻿using HotelBediaX.Application.Interfaces;
+using HotelBediaX.Application.Interfaces;
 using HotelBediaX.Domain.Entities;
+using System.Threading;
 
 namespace HotelBediaX.Application.UseCases.DestinationUseCases;
 
@@ -7,8 +8,9 @@ public class GetByIdUseCase(IDestinationRepository repository)
 {
     private readonly IDestinationRepository _repository = repository;
 
-    public async Task<Destination?> ExecuteAsync(int id)
+    public async Task<Destination?> ExecuteAsync(int id, CancellationToken cancellationToken)
     {
-        return await _repository.GetByIdAsync(id);
+        return await _repository.GetByIdAsync(id, cancellationToken);
     }
 }
+

--- a/HotelBediaX.Application/UseCases/DestinationUseCases/UpdateUseCase.cs
+++ b/HotelBediaX.Application/UseCases/DestinationUseCases/UpdateUseCase.cs
@@ -1,24 +1,25 @@
-﻿using HotelBediaX.Application.Interfaces;
+using HotelBediaX.Application.Interfaces;
+using System.Threading;
 
-namespace HotelBediaX.Application.UseCases.DestinationUseCases
+namespace HotelBediaX.Application.UseCases.DestinationUseCases;
+
+public class UpdateUseCase(IDestinationRepository repository)
 {
-    public class UpdateUseCase(IDestinationRepository repository)
+    private readonly IDestinationRepository _repository = repository;
+
+    public async Task ExecuteAsync(UpdateDto dto, CancellationToken cancellationToken)
     {
-        private readonly IDestinationRepository _repository = repository;
+        var existing = await _repository.GetByIdAsync(dto.Id, cancellationToken);
+        if (existing is null)
+            throw new InvalidOperationException($"Destination with ID {dto.Id} not found");
 
-        public async Task ExecuteAsync(UpdateDto dto)
-        {
-            var existing = await _repository.GetByIdAsync(dto.Id);
-            if (existing is null)
-                throw new InvalidOperationException($"Destination with ID {dto.Id} not found");
+        existing.Name = dto.Name;
+        existing.CountryCode = dto.CountryCode;
+        existing.Description = dto.Description;
+        existing.Type = dto.Type;
+        existing.UpdatedDate = DateTime.UtcNow;
 
-            existing.Name = dto.Name;
-            existing.CountryCode = dto.CountryCode;
-            existing.Description = dto.Description;
-            existing.Type = dto.Type;
-            existing.UpdatedDate = DateTime.UtcNow;
-
-            await _repository.UpdateAsync(existing);
-        }
+        await _repository.UpdateAsync(existing, cancellationToken);
     }
 }
+

--- a/HotelBediaX.Infrastructure/Repositories/DestinationRepository.cs
+++ b/HotelBediaX.Infrastructure/Repositories/DestinationRepository.cs
@@ -1,78 +1,80 @@
-﻿using HotelBediaX.Application.Interfaces;
+using HotelBediaX.Application.Interfaces;
 using HotelBediaX.Application.UseCases.Common;
 using HotelBediaX.Domain.Entities;
 using HotelBediaX.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
+using System.Threading;
 
-namespace HotelBediaX.Infrastructure.Repositories
+namespace HotelBediaX.Infrastructure.Repositories;
+
+public class DestinationRepository(AppDbContext context) : IDestinationRepository
 {
-    public class DestinationRepository(AppDbContext context) : IDestinationRepository
+    private readonly AppDbContext _context = context;
+
+    public async Task<int> AddAsync(Destination destination, CancellationToken cancellationToken)
     {
-        private readonly AppDbContext _context = context;
+        _context.Destinations.Add(destination);
+        await _context.SaveChangesAsync(cancellationToken);
+        return destination.Id;
+    }
 
-        public async Task<int> AddAsync(Destination destination)
+    public async Task DeleteAsync(int id, CancellationToken cancellationToken)
+    {
+        var entity = await _context.Destinations.FindAsync(new object?[] { id }, cancellationToken);
+        if (entity is not null)
         {
-            _context.Destinations.Add(destination);
-            await _context.SaveChangesAsync();
-            return destination.Id;
-        }
-
-        public async Task DeleteAsync(int id)
-        {
-            var entity = await _context.Destinations.FindAsync(id);
-            if (entity is not null)
-            {
-                _context.Destinations.Remove(entity);
-                await _context.SaveChangesAsync();
-            }
-        }
-
-        public async Task<Pagination<Destination>> GetAllAsync(
-            int pageNumber = 1,
-            int pageSize = 10,
-            string? filter = null)
-        {
-            var query = _context.Destinations.AsQueryable();
-
-            if (!string.IsNullOrWhiteSpace(filter))
-            {
-                var normalizedFilter = filter.Trim().ToLower();
-
-                query = query.Where(d =>
-                    d.Name.ToLower().Contains(normalizedFilter) ||
-                    d.CountryCode.ToLower().Contains(normalizedFilter) ||
-                    (d.Description != null && d.Description.ToLower().Contains(normalizedFilter)) ||
-                    d.Type.ToString().ToLower().Contains(normalizedFilter));
-            }
-
-            var totalElements = await query.CountAsync();
-
-            var items = await query
-                .OrderBy(d => d.Id)
-                .Skip((pageNumber - 1) * pageSize)
-                .Take(pageSize)
-                .ToListAsync();
-
-            return new Pagination<Destination>
-            {
-                Content = items,
-                TotalElements = totalElements,
-                TotalPages = (int)Math.Ceiling(totalElements / (double)pageSize),
-                Size = pageSize,
-                Number = pageNumber
-            };
-        }
-
-
-        public async Task<Destination?> GetByIdAsync(int id)
-        {
-            return await _context.Destinations.FindAsync(id);
-        }
-
-        public async Task UpdateAsync(Destination destination)
-        {
-            _context.Destinations.Update(destination);
-            await _context.SaveChangesAsync();
+            _context.Destinations.Remove(entity);
+            await _context.SaveChangesAsync(cancellationToken);
         }
     }
+
+    public async Task<Pagination<Destination>> GetAllAsync(
+        int pageNumber = 1,
+        int pageSize = 10,
+        string? filter = null,
+        CancellationToken cancellationToken = default)
+    {
+        var query = _context.Destinations.AsQueryable();
+
+        if (!string.IsNullOrWhiteSpace(filter))
+        {
+            var normalizedFilter = filter.Trim().ToLower();
+
+            query = query.Where(d =>
+                d.Name.ToLower().Contains(normalizedFilter) ||
+                d.CountryCode.ToLower().Contains(normalizedFilter) ||
+                (d.Description != null && d.Description.ToLower().Contains(normalizedFilter)) ||
+                d.Type.ToString().ToLower().Contains(normalizedFilter));
+        }
+
+        var totalElements = await query.CountAsync(cancellationToken);
+
+        var items = await query
+            .OrderBy(d => d.Id)
+            .Skip((pageNumber - 1) * pageSize)
+            .Take(pageSize)
+            .ToListAsync(cancellationToken);
+
+        return new Pagination<Destination>
+        {
+            Content = items,
+            TotalElements = totalElements,
+            TotalPages = (int)Math.Ceiling(totalElements / (double)pageSize),
+            Size = pageSize,
+            Number = pageNumber
+        };
+    }
+
+
+    public async Task<Destination?> GetByIdAsync(int id, CancellationToken cancellationToken)
+    {
+        return await _context.Destinations.FindAsync(new object?[] { id }, cancellationToken);
+    }
+
+    public async Task UpdateAsync(Destination destination, CancellationToken cancellationToken)
+    {
+        _context.Destinations.Update(destination);
+        await _context.SaveChangesAsync(cancellationToken);
+    }
 }
+

--- a/HotelBediaX.Tests/UseCases/DestinationTest/CreateTests.cs
+++ b/HotelBediaX.Tests/UseCases/DestinationTest/CreateTests.cs
@@ -14,7 +14,7 @@ namespace HotelBediaX.Tests.UseCases.DestinationTest
         {
             // Arrange
             var mockRepo = new Mock<IDestinationRepository>();
-            mockRepo.Setup(r => r.AddAsync(It.IsAny<Destination>())).ReturnsAsync(1);
+            mockRepo.Setup(r => r.AddAsync(It.IsAny<Destination>(), It.IsAny<CancellationToken>())).ReturnsAsync(1);
 
             var useCase = new CreateUseCase(mockRepo.Object);
 
@@ -27,11 +27,11 @@ namespace HotelBediaX.Tests.UseCases.DestinationTest
             };
 
             // Act
-            var id = await useCase.ExecuteAsync(command);
+            var id = await useCase.ExecuteAsync(command, CancellationToken.None);
 
             // Assert
             id.Should().Be(1);
-            mockRepo.Verify(r => r.AddAsync(It.IsAny<Destination>()), Times.Once);
+            mockRepo.Verify(r => r.AddAsync(It.IsAny<Destination>(), It.IsAny<CancellationToken>()), Times.Once);
         }
     }
 }

--- a/HotelBediaX.WebApi/Controllers/DestinationController.cs
+++ b/HotelBediaX.WebApi/Controllers/DestinationController.cs
@@ -1,14 +1,15 @@
-﻿using HotelBediaX.Application.UseCases.DestinationUseCases;
+using HotelBediaX.Application.UseCases.DestinationUseCases;
 using Microsoft.AspNetCore.Mvc;
+using System.Threading;
 
 namespace HotelBediaX.WebApi.Controllers;
 
 [ApiController]
 [Route("api/[controller]")]
 public class DestinationController(
-    CreateUseCase createUseCase, 
-    GetByIdUseCase getById, 
-    GetAllUseCase getAll, 
+    CreateUseCase createUseCase,
+    GetByIdUseCase getById,
+    GetAllUseCase getAll,
     UpdateUseCase updateUseCase,
     DeleteUseCase deleteUseCase
     ) : ControllerBase
@@ -20,19 +21,19 @@ public class DestinationController(
     private readonly DeleteUseCase _deleteUseCase = deleteUseCase;
 
     [HttpPost]
-    public async Task<IActionResult> CreateDestination([FromBody] CreateDto dto)
+    public async Task<IActionResult> CreateDestination([FromBody] CreateDto dto, CancellationToken cancellationToken)
     {
         if (!ModelState.IsValid)
             return BadRequest(ModelState);
 
-        var id = await _createUseCase.ExecuteAsync(dto);
+        var id = await _createUseCase.ExecuteAsync(dto, cancellationToken);
         return CreatedAtAction(nameof(GetById), new { id }, new { id });
     }
 
     [HttpGet("{id:int}")]
-    public async Task<IActionResult> GetById(int id)
+    public async Task<IActionResult> GetById(int id, CancellationToken cancellationToken)
     {
-        var result = await _getById.ExecuteAsync(id);
+        var result = await _getById.ExecuteAsync(id, cancellationToken);
         return result is not null ? Ok(result) : NotFound();
     }
 
@@ -40,15 +41,16 @@ public class DestinationController(
     public async Task<IActionResult> GetAll(
         [FromQuery] string? filter,
         [FromQuery] int pageNumber = 1,
-        [FromQuery] int pageSize = 10)
+        [FromQuery] int pageSize = 10,
+        CancellationToken cancellationToken = default)
     {
-        var results = await _getAll.ExecuteAsync(pageNumber, pageSize, filter);
+        var results = await _getAll.ExecuteAsync(pageNumber, pageSize, filter, cancellationToken);
         return Ok(results);
     }
 
 
     [HttpPut("{id:int}")]
-    public async Task<IActionResult> UpdateDestination(int id, [FromBody] UpdateDto dto)
+    public async Task<IActionResult> UpdateDestination(int id, [FromBody] UpdateDto dto, CancellationToken cancellationToken)
     {
         if (id != dto.Id)
             return BadRequest("ID in URL and body do not match.");
@@ -58,7 +60,7 @@ public class DestinationController(
 
         try
         {
-            await _updateUseCase.ExecuteAsync(dto);
+            await _updateUseCase.ExecuteAsync(dto, cancellationToken);
             return NoContent();
         }
         catch (InvalidOperationException ex)
@@ -68,9 +70,10 @@ public class DestinationController(
     }
 
     [HttpDelete("{id:int}")]
-    public async Task<IActionResult> Delete(int id)
+    public async Task<IActionResult> Delete(int id, CancellationToken cancellationToken)
     {
-        await _deleteUseCase.ExecuteAsync(id);
+        await _deleteUseCase.ExecuteAsync(id, cancellationToken);
         return NoContent();
     }
 }
+


### PR DESCRIPTION
## Summary
- allow DestinationRepository and IDestinationRepository methods to accept `CancellationToken`
- pass cancellation tokens through Destination use cases and controller actions
- update tests for new repository signature

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bda2b22a50832f9627c7dcdb5654cb