### PR TITLE
Handle missing destinations on deletion

### DIFF
--- a/HotelBediaX.Application/UseCases/DestinationUseCases/DeleteUseCase.cs
+++ b/HotelBediaX.Application/UseCases/DestinationUseCases/DeleteUseCase.cs
@@ -6,9 +6,14 @@ namespace HotelBediaX.Application.UseCases.DestinationUseCases
     {
         private readonly IDestinationRepository _repository = repository;
 
-        public async Task ExecuteAsync(int id)
+        public async Task<bool> ExecuteAsync(int id)
         {
+            var destination = await _repository.GetByIdAsync(id);
+            if (destination is null)
+                return false;
+
             await _repository.DeleteAsync(id);
+            return true;
         }
     }
 }

--- a/HotelBediaX.WebApi/Controllers/DestinationController.cs
+++ b/HotelBediaX.WebApi/Controllers/DestinationController.cs
@@ -70,7 +70,7 @@ public class DestinationController(
     [HttpDelete("{id:int}")]
     public async Task<IActionResult> Delete(int id)
     {
-        await _deleteUseCase.ExecuteAsync(id);
-        return NoContent();
+        var deleted = await _deleteUseCase.ExecuteAsync(id);
+        return deleted ? NoContent() : NotFound();
     }
 }


### PR DESCRIPTION
## Summary
- return bool from destination delete use case to indicate if delete occurred
- return 404 when deleting a destination that does not exist

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bda2da100c832fbf8ba2ee1f1d3963