### PR TITLE
Fix destination use case tests

### DIFF
--- a/HotelBediaX.Tests/UseCases/DestinationTest/CreateTests.cs
+++ b/HotelBediaX.Tests/UseCases/DestinationTest/CreateTests.cs
@@ -4,6 +4,7 @@ using HotelBediaX.Application.UseCases.DestinationUseCases;
 using HotelBediaX.Domain.Enums;
 using HotelBediaX.Domain.Entities;
 using Moq;
+using System.Threading;
 
 namespace HotelBediaX.Tests.UseCases.DestinationTest
 {

--- a/HotelBediaX.Tests/UseCases/DestinationTest/DeleteTests.cs
+++ b/HotelBediaX.Tests/UseCases/DestinationTest/DeleteTests.cs
@@ -1,6 +1,9 @@
+using FluentAssertions;
 using HotelBediaX.Application.Interfaces;
 using HotelBediaX.Application.UseCases.DestinationUseCases;
+using HotelBediaX.Domain.Entities;
 using Moq;
+using System.Threading;
 
 namespace HotelBediaX.Tests.UseCases.DestinationTest
 {
@@ -11,14 +14,36 @@ namespace HotelBediaX.Tests.UseCases.DestinationTest
         {
             // Arrange
             var mockRepo = new Mock<IDestinationRepository>();
-            mockRepo.Setup(r => r.DeleteAsync(1)).Returns(Task.CompletedTask);
+            mockRepo.Setup(r => r.GetByIdAsync(1, It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(new Destination());
+            mockRepo.Setup(r => r.DeleteAsync(1, It.IsAny<CancellationToken>()))
+                    .Returns(Task.CompletedTask);
             var useCase = new DeleteUseCase(mockRepo.Object);
 
             // Act
-            await useCase.ExecuteAsync(1);
+            var result = await useCase.ExecuteAsync(1, CancellationToken.None);
 
             // Assert
-            mockRepo.Verify(r => r.DeleteAsync(1), Times.Once);
+            result.Should().BeTrue();
+            mockRepo.Verify(r => r.GetByIdAsync(1, It.IsAny<CancellationToken>()), Times.Once);
+            mockRepo.Verify(r => r.DeleteAsync(1, It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task Should_Return_False_When_Destination_Not_Found()
+        {
+            // Arrange
+            var mockRepo = new Mock<IDestinationRepository>();
+            mockRepo.Setup(r => r.GetByIdAsync(1, It.IsAny<CancellationToken>()))
+                    .ReturnsAsync((Destination?)null);
+            var useCase = new DeleteUseCase(mockRepo.Object);
+
+            // Act
+            var result = await useCase.ExecuteAsync(1, CancellationToken.None);
+
+            // Assert
+            result.Should().BeFalse();
+            mockRepo.Verify(r => r.DeleteAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()), Times.Never);
         }
     }
 }

--- a/HotelBediaX.Tests/UseCases/DestinationTest/GetAllTests.cs
+++ b/HotelBediaX.Tests/UseCases/DestinationTest/GetAllTests.cs
@@ -1,0 +1,54 @@
+using FluentAssertions;
+using HotelBediaX.Application.Interfaces;
+using HotelBediaX.Application.UseCases.Common;
+using HotelBediaX.Application.UseCases.DestinationUseCases;
+using HotelBediaX.Domain.Entities;
+using HotelBediaX.Domain.Enums;
+using Moq;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace HotelBediaX.Tests.UseCases.DestinationTest
+{
+    public class GetAllTests
+    {
+        [Fact]
+        public async Task Should_Call_Repository_And_Return_Pagination()
+        {
+            // Arrange
+            var pagination = new Pagination<Destination>
+            {
+                Content = new List<Destination>
+                {
+                    new()
+                    {
+                        Id = 1,
+                        Name = "Sample",
+                        CountryCode = "SS",
+                        Type = DestinationType.City,
+                        CreatedDate = DateTime.UtcNow,
+                        UpdatedDate = DateTime.UtcNow
+                    }
+                },
+                TotalElements = 1,
+                TotalPages = 1,
+                Size = 10,
+                Number = 1
+            };
+
+            var mockRepo = new Mock<IDestinationRepository>();
+            mockRepo.Setup(r => r.GetAllAsync(1, 10, null, It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(pagination);
+
+            var useCase = new GetAllUseCase(mockRepo.Object);
+
+            // Act
+            var result = await useCase.ExecuteAsync(1, 10, null, CancellationToken.None);
+
+            // Assert
+            result.Should().Be(pagination);
+            mockRepo.Verify(r => r.GetAllAsync(1, 10, null, It.IsAny<CancellationToken>()), Times.Once);
+        }
+    }
+}
+

--- a/HotelBediaX.Tests/UseCases/DestinationTest/GetByIdTests.cs
+++ b/HotelBediaX.Tests/UseCases/DestinationTest/GetByIdTests.cs
@@ -4,6 +4,7 @@ using HotelBediaX.Application.UseCases.DestinationUseCases;
 using HotelBediaX.Domain.Entities;
 using HotelBediaX.Domain.Enums;
 using Moq;
+using System.Threading;
 
 namespace HotelBediaX.Tests.UseCases.DestinationTest
 {
@@ -22,15 +23,16 @@ namespace HotelBediaX.Tests.UseCases.DestinationTest
                 Type = DestinationType.Beach
             };
             var mockRepo = new Mock<IDestinationRepository>();
-            mockRepo.Setup(r => r.GetByIdAsync(1)).ReturnsAsync(expected);
+            mockRepo.Setup(r => r.GetByIdAsync(1, It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(expected);
             var useCase = new GetByIdUseCase(mockRepo.Object);
 
             // Act
-            var result = await useCase.ExecuteAsync(1);
+            var result = await useCase.ExecuteAsync(1, CancellationToken.None);
 
             // Assert
             result.Should().Be(expected);
-            mockRepo.Verify(r => r.GetByIdAsync(1), Times.Once);
+            mockRepo.Verify(r => r.GetByIdAsync(1, It.IsAny<CancellationToken>()), Times.Once);
         }
     }
 }

--- a/HotelBediaX.Tests/UseCases/DestinationTest/UpdateTests.cs
+++ b/HotelBediaX.Tests/UseCases/DestinationTest/UpdateTests.cs
@@ -4,6 +4,7 @@ using HotelBediaX.Application.UseCases.DestinationUseCases;
 using HotelBediaX.Domain.Entities;
 using HotelBediaX.Domain.Enums;
 using Moq;
+using System.Threading;
 
 namespace HotelBediaX.Tests.UseCases.DestinationTest
 {
@@ -23,8 +24,10 @@ namespace HotelBediaX.Tests.UseCases.DestinationTest
                 CreatedDate = DateTime.UtcNow
             };
             var mockRepo = new Mock<IDestinationRepository>();
-            mockRepo.Setup(r => r.GetByIdAsync(existing.Id)).ReturnsAsync(existing);
-            mockRepo.Setup(r => r.UpdateAsync(It.IsAny<Destination>())).Returns(Task.CompletedTask);
+            mockRepo.Setup(r => r.GetByIdAsync(existing.Id, It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(existing);
+            mockRepo.Setup(r => r.UpdateAsync(It.IsAny<Destination>(), It.IsAny<CancellationToken>()))
+                    .Returns(Task.CompletedTask);
             var useCase = new UpdateUseCase(mockRepo.Object);
 
             var dto = new UpdateDto
@@ -37,10 +40,10 @@ namespace HotelBediaX.Tests.UseCases.DestinationTest
             };
 
             // Act
-            await useCase.ExecuteAsync(dto);
+            await useCase.ExecuteAsync(dto, CancellationToken.None);
 
             // Assert
-            mockRepo.Verify(r => r.GetByIdAsync(existing.Id), Times.Once);
+            mockRepo.Verify(r => r.GetByIdAsync(existing.Id, It.IsAny<CancellationToken>()), Times.Once);
             mockRepo.Verify(r => r.UpdateAsync(It.Is<Destination>(d =>
                 d.Id == dto.Id &&
                 d.Name == dto.Name &&
@@ -48,7 +51,7 @@ namespace HotelBediaX.Tests.UseCases.DestinationTest
                 d.Description == dto.Description &&
                 d.Type == dto.Type &&
                 d.UpdatedDate != default
-            )), Times.Once);
+            ), It.IsAny<CancellationToken>()), Times.Once);
         }
     }
 }


### PR DESCRIPTION
## Summary
- update destination tests for new cancellation token parameters
- add coverage for destination list use case and deletion failure scenario

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68bda7bf0ab4832fbb6cb8ff11343c19